### PR TITLE
Speed up build process if code changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ EXPOSE 8000
 # 设置当前目录为工作目录
 WORKDIR /app
 
-COPY . /app
+# Copy only the necessary files for pip install
+COPY requirements.txt /app
 
 # apt-get换源并安装依赖
 RUN sed -i "s@http://deb.debian.org@http://mirrors.tuna.tsinghua.edu.cn@g" /etc/apt/sources.list
@@ -18,6 +19,9 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN python3 -m pip install -i https://pypi.tuna.tsinghua.edu.cn/simple --upgrade pip
 RUN pip3 config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
 RUN pip3 install -r requirements.txt
+
+# Copy the rest
+COPY . /app
 
 # CMD ["python3", "./main.py"]
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0"]


### PR DESCRIPTION
Currently, the Docker build process takes a lot of time if any file changes, because it invalidates Docker’s layer cache and rebuilds everything.